### PR TITLE
Add response headers for Referrer-Policy and DNS prefetch control

### DIFF
--- a/rootfs/nginx/sites-enabled/nginx.conf
+++ b/rootfs/nginx/sites-enabled/nginx.conf
@@ -1,15 +1,17 @@
 server {
         listen 8888;
         root /nextcloud;
-        
+
         fastcgi_buffers 64 4K;
-        
+
+        add_header Referrer-Policy strict-origin-when-cross-origin;
         add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload";
         add_header X-Content-Type-Options nosniff;
-        add_header X-XSS-Protection "1; mode=block";
-        add_header X-Robots-Tag none;
+        add_header X-Dns-Prefetch-Control off;
         add_header X-Download-Options noopen;
         add_header X-Permitted-Cross-Domain-Policies none;
+        add_header X-Robots-Tag none;
+        add_header X-XSS-Protection "1; mode=block";
 
         location = /robots.txt {
             allow all;


### PR DESCRIPTION
First, a huge thanks, Ben, for stepping up and maintaining this image - mucho respect!! 🙇 

The Admin security check currently throws this warning:

![image](https://user-images.githubusercontent.com/18492423/46375076-ad4f9980-c692-11e8-97cb-474b0b831336.png)

This PR adds 2 security related response headers responses via Nginx:

### Referrer-Policy

I chose to fix it with **"strict-origin-when-cross-origin"**:

> Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP).

_- [Referrer-Policy - HTTP | MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy#Directives)_

### X-DNS-Prefetch-Control: off

Disabling DNS Prefetch is relatively minor but nonetheless contributes to ensuring user privacy. 

> Browsers can start these DNS requests before the user even clicks a link or loads a resource from somewhere. This improves performance when the user clicks the link, but has privacy implications for users. It can appear as if a user is visiting things they aren’t visiting.

_- [DNS Prefetch Control - Helmet](https://helmetjs.github.io/docs/dns-prefetch-control/)_

Nextcloud itself doesn't use `dns-prefetch` meta-tags AFAIK, but third-party plugins well could.

------

A test build of Dockerfile.14.0 with the above changes gives us:

![image](https://user-images.githubusercontent.com/18492423/46375186-07505f00-c693-11e8-85a5-aaa4eaba754f.png)

And we all sleep easier with a green check-mark icon 😎
