### PR TITLE
fix well-known dav redirect

### DIFF
--- a/rootfs/nginx/sites-enabled/nginx.conf
+++ b/rootfs/nginx/sites-enabled/nginx.conf
@@ -1,3 +1,11 @@
+# Sets a $real_scheme variable whose value is the scheme passed by the load
+# balancer in X-Forwarded-Proto (if any), defaulting to $scheme.
+# Similar to how the HttpRealIp module treats X-Forwarded-For.
+map $http_x_forwarded_proto $real_scheme {
+  default $http_x_forwarded_proto;
+  ''      $scheme;
+}
+
 server {
         listen 8888;
         root /nextcloud;
@@ -20,11 +28,11 @@ server {
         }
 
         location = /.well-known/carddav {
-            return 301 $scheme://$host/remote.php/dav;
+            return 301 $real_scheme://$host/remote.php/dav;
         }
 
         location = /.well-known/caldav {
-            return 301 $scheme://$host/remote.php/dav;
+            return 301 $real_scheme://$host/remote.php/dav;
         }
 
         location / {


### PR DESCRIPTION
nginx sets the scheme variable to the communication protocol it uses
with the reverse proxy. which is http, since the container doesn't
listen for https connections.

well-known urls therefore redirect to http://your-domain/remote.php/dav
instead of https://

this causes the browser to block the self check request in the admin
panel because of a content security policy that only allows self links
(and self is https:// and not http://)